### PR TITLE
added support for es6 & updated tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# top-most EditorConfig file
+root = true
+
+[*.js]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+

--- a/package.json
+++ b/package.json
@@ -24,9 +24,11 @@
   },
   "dependencies": {
     "estraverse": "^1.9.1",
-    "object-assign": "^2.0.0"
+    "object-assign": "^2.0.0",
+    "shift-spec": "^2.1.1"
   },
   "devDependencies": {
+    "everything.js": "^1.0.0",
     "gulp": "^3.8.10",
     "gulp-6to5": "^1.0.2",
     "gulp-bump": "^0.1.11",
@@ -41,7 +43,7 @@
     "power-assert": "^0.10.0",
     "shift-ast": "^1.0.1",
     "shift-codegen": "^1.0.0",
-    "shift-parser": "^1.0.0"
+    "shift-parser": "^2.0.0"
   },
   "keywords": [
     "Shift",

--- a/src/spec.js
+++ b/src/spec.js
@@ -22,63 +22,20 @@
   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-const SPEC = {
-  ArrayExpression: ['elements'],
-  AssignmentExpression: ['binding', 'expression'],
-  BinaryExpression: ['left', 'right'],
-  Block: ['statements'],
-  BlockStatement: ['block'],
-  BreakStatement: ['label'],
-  CallExpression: ['callee', 'arguments'],
-  CatchClause: ['binding', 'body'],
-  ComputedMemberExpression: ['object', 'expression'],
-  ConditionalExpression: ['test', 'consequent', 'alternate'],
-  ContinueStatement: ['label'],
-  DataProperty: ['name', 'expression'],
-  DebuggerStatement: [],
-  DoWhileStatement: ['body', 'test'],
-  EmptyStatement: [],
-  ExpressionStatement: ['expression'],
-  ForInStatement: ['left', 'right', 'body'],
-  ForStatement: ['init', 'test', 'update', 'body'],
-  FunctionBody: ['directives', 'statements'],
-  FunctionDeclaration: ['name', 'parameters', 'body'],
-  FunctionExpression: ['name', 'parameters', 'body'],
-  Getter: ['name', 'body'],
-  Identifier: [],
-  IdentifierExpression: ['identifier'],
-  IfStatement: ['test', 'consequent', 'alternate'],
-  LabeledStatement: ['label', 'body'],
-  LiteralBooleanExpression: [],
-  LiteralNullExpression: [],
-  LiteralNumericExpression: [],
-  LiteralRegExpExpression: [],
-  LiteralStringExpression: [],
-  NewExpression: ['callee', 'arguments'],
-  ObjectExpression: ['properties'],
-  PostfixExpression: ['operand'],
-  PrefixExpression: ['operand'],
-  PropertyName: [],
-  ReturnStatement: ['expression'],
-  Script: ['body'],
-  Setter: ['name', 'parameter', 'body'],
-  StaticMemberExpression: ['object', 'property'],
-  SwitchCase: ['test', 'consequent'],
-  SwitchDefault: ['consequent'],
-  SwitchStatement: ['discriminant', 'cases'],
-  SwitchStatementWithDefault: ['discriminant', 'preDefaultCases', 'defaultCase', 'postDefaultCases'],
-  ThisExpression: [],
-  ThrowStatement: ['expression'],
-  TryCatchStatement: ['body', 'catchClause'],
-  TryFinallyStatement: ['body', 'catchClause', 'finalizer'],
-  UnknownDirective: [],
-  UseStrictDirective: [],
-  VariableDeclaration: ['declarators'],
-  VariableDeclarationStatement: ['declaration'],
-  VariableDeclarator: ['binding', 'init'],
-  WhileStatement: ['test', 'body'],
-  WithStatement: ['object', 'body'],
-};
+"use strict";
+
+import shiftSpec from 'shift-spec';
+
+var SPEC = {};
+
+Object.keys(shiftSpec).forEach((specProperty) => {
+    var node = shiftSpec[specProperty];
+    SPEC[node.typeName] = node.fields.map(x => x.name);
+});
+
+// Need to explicitly set a 'Property' for the estraverse spec due to the logic it
+// uses to generalize properties
+SPEC.Property = ['name'];
 
 export default SPEC;
 

--- a/test/replace.js
+++ b/test/replace.js
@@ -24,9 +24,7 @@
 
 import * as assert from 'power-assert'
 import parse from 'shift-parser'
-import codegen from "shift-codegen";
-import { LiteralStringExpression } from "shift-ast";
-import { replace, Syntax } from '../'
+import { replace, Syntax } from '../';
 
 describe('replace', () => {
     it('string literal', () => {
@@ -39,11 +37,11 @@ describe('replace', () => {
         let transformed = replace(tree, {
             enter(node, parent) {
                 if (node.type === Syntax.LiteralStringExpression) {
-                    return new LiteralStringExpression('ご注文はうさぎですか？');
+                    return { type: "LiteralStringExpression", value: 'ご注文はうさぎですか？' };
                 }
             }
         });
-        assert(codegen(transformed) === `function test(){console.log("ご注文はうさぎですか？")}`);
+        assert.equal(transformed.body.statements[0].body.statements[0].expression.arguments[0].value, 'ご注文はうさぎですか？');
     });
 });
 

--- a/test/traverse.js
+++ b/test/traverse.js
@@ -22,8 +22,10 @@
   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+import * as fs from 'fs';
+
 import * as assert from 'power-assert'
-import parse from 'shift-parser'
+import {parseScript, parseModule} from 'shift-parser'
 import { traverse } from '../'
 
 describe('traverse', () => {
@@ -33,7 +35,7 @@ describe('traverse', () => {
             console.log("HELLO WORLD");
         }
         `;
-        let tree = parse(code);
+        let tree = parseScript(code);
         let result = [];
         traverse(tree, {
             enter(node) {
@@ -41,18 +43,17 @@ describe('traverse', () => {
             }
         });
         assert.deepEqual(result, [
-            'Script',
-            'FunctionBody',
-            'FunctionDeclaration',
-            'Identifier',
-            'FunctionBody',
-            'ExpressionStatement',
-            'CallExpression',
-            'StaticMemberExpression',
-            'IdentifierExpression',
-            'Identifier',
-            'Identifier',
-            'LiteralStringExpression'
+            "Script",
+            "FunctionBody",
+            "FunctionDeclaration",
+            "BindingIdentifier",
+            "FormalParameters",
+            "FunctionBody",
+            "ExpressionStatement",
+            "CallExpression",
+            "StaticMemberExpression",
+            "IdentifierExpression",
+            "LiteralStringExpression"
         ]);
     });
 
@@ -62,7 +63,7 @@ describe('traverse', () => {
             console.log("HELLO WORLD");
         }
         `;
-        let tree = parse(code);
+        let tree = parseScript(code);
         let result = [];
         traverse(tree, {
             leave(node) {
@@ -70,18 +71,17 @@ describe('traverse', () => {
             }
         });
         assert.deepEqual(result, [
-            'Identifier',
-            'Identifier',
-            'IdentifierExpression',
-            'Identifier',
-            'StaticMemberExpression',
-            'LiteralStringExpression',
-            'CallExpression',
-            'ExpressionStatement',
-            'FunctionBody',
-            'FunctionDeclaration',
-            'FunctionBody',
-            'Script'
+            "BindingIdentifier",
+            "FormalParameters",
+            "IdentifierExpression",
+            "StaticMemberExpression",
+            "LiteralStringExpression",
+            "CallExpression",
+            "ExpressionStatement",
+            "FunctionBody",
+            "FunctionDeclaration",
+            "FunctionBody",
+            "Script"
         ]);
     });
 
@@ -91,7 +91,7 @@ describe('traverse', () => {
             console.log("HELLO WORLD");
         }
         `;
-        let tree = parse(code);
+        let tree = parseScript(code);
         let result = [];
         traverse(tree, {
             enter(node) {
@@ -103,32 +103,57 @@ describe('traverse', () => {
             }
         });
         assert.deepEqual(result, [
-            'enter:Script',
-            'enter:FunctionBody',
-            'enter:FunctionDeclaration',
-            'enter:Identifier',
-            'leave:Identifier',
-            'enter:FunctionBody',
-            'enter:ExpressionStatement',
-            'enter:CallExpression',
-            'enter:StaticMemberExpression',
-            'enter:IdentifierExpression',
-            'enter:Identifier',
-            'leave:Identifier',
-            'leave:IdentifierExpression',
-            'enter:Identifier',
-            'leave:Identifier',
-            'leave:StaticMemberExpression',
-            'enter:LiteralStringExpression',
-            'leave:LiteralStringExpression',
-            'leave:CallExpression',
-            'leave:ExpressionStatement',
-            'leave:FunctionBody',
-            'leave:FunctionDeclaration',
-            'leave:FunctionBody',
-            'leave:Script'
+            "enter:Script",
+            "enter:FunctionBody",
+            "enter:FunctionDeclaration",
+            "enter:BindingIdentifier",
+            "leave:BindingIdentifier",
+            "enter:FormalParameters",
+            "leave:FormalParameters",
+            "enter:FunctionBody",
+            "enter:ExpressionStatement",
+            "enter:CallExpression",
+            "enter:StaticMemberExpression",
+            "enter:IdentifierExpression",
+            "leave:IdentifierExpression",
+            "leave:StaticMemberExpression",
+            "enter:LiteralStringExpression",
+            "leave:LiteralStringExpression",
+            "leave:CallExpression",
+            "leave:ExpressionStatement",
+            "leave:FunctionBody",
+            "leave:FunctionDeclaration",
+            "leave:FunctionBody",
+            "leave:Script"
         ]);
     });
-})
+
+    it('should traverse es2015 modules', () => {
+        let code = fs.readFileSync('./node_modules/everything.js/es2015-module.js');
+        let tree = parseModule(code.toString());
+        let result = [];
+
+        traverse(tree, {
+            enter(node) {
+                result.push(node.type);
+            }
+        });
+        // not the best looking test but tests both that the number of nodes traversed doesn't decrease
+        // and that estraverse doesn't throw on any unfound nodes.
+        assert(result.length >= 1833);
+    });
+
+    it('should traverse es2015 scripts', () => {
+        let code = fs.readFileSync('./node_modules/everything.js/es2015-script.js');
+        let tree = parseScript(code.toString());
+        let result = [];
+        traverse(tree, {
+            enter(node) {
+                result.push(node.type);
+            }
+        });
+        assert(result.length >= 1224);
+    });
+});
 
 /* vim: set sw=4 ts=4 et tw=80 : */


### PR DESCRIPTION
Updated to support es6 ast generated from shift-parser 2.x. The spec will now be generated from the distributed spec instead of hard coded.

Let me know if I missed anything. Notes, I removed the codegen dependency because that hasn't been updated for es6 yet, and I also am not entirely sure whether or not https://github.com/Constellation/shift-traverse-js/compare/master...jsoverson:es6?expand=1#diff-f05deff17c454e8853b82c491ac2f0ceR38 was the best way to get around the `Property` issue.
