### PR TITLE
Update for shift 2017

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,13 @@
     "lib"
   ],
   "scripts": {
-    "test": "gulp test"
+    "test": "gulp test",
+    "build": "gulp build"
   },
   "dependencies": {
-    "estraverse": "^1.9.1",
+    "estraverse": "^4.2.0",
     "object-assign": "^2.0.0",
-    "shift-spec": "^2015.1.3"
+    "shift-spec": "^2018.0.0"
   },
   "devDependencies": {
     "everything.js": "1.0.3",
@@ -34,15 +35,16 @@
     "gulp-bump": "^0.1.11",
     "gulp-espower": "^0.10.0",
     "gulp-filter": "^2.0.0",
-    "gulp-git": "^0.5.5",
+    "gulp-git": "^2.8.0",
     "gulp-mocha": "^2.0.0",
     "gulp-plumber": "^0.6.6",
     "gulp-sourcemaps": "^1.3.0",
     "gulp-tag-version": "^1.2.1",
     "lazypipe": "^0.2.2",
     "power-assert": "^0.10.0",
-    "shift-codegen": "^3.0.0",
-    "shift-parser": "^3.0.1"
+    "shift-codegen": "^6.0.0",
+    "shift-parser": "^6.0.1",
+    "shift-reducer": "^5.0.0"
   },
   "keywords": [
     "Shift",


### PR DESCRIPTION
Includes update to estraverse 4.2 and minimal dependency updates to ensure tests run.

There are a number of updates that could also be added to bring the repo up-to-date with modern practices but those are probably better in another PR.